### PR TITLE
fix(maintner): bucket name pefixed properly

### DIFF
--- a/drghs-worker/cmd/main.go
+++ b/drghs-worker/cmd/main.go
@@ -106,7 +106,7 @@ func main() {
 		log.Fatal(err)
 	}
 
-	gl, err := gcslog.NewGCSLog(ctx, fmt.Sprintf("%v/%v/%v", *bucket, *owner, *repo))
+	gl, err := gcslog.NewGCSLog(ctx, fmt.Sprintf("%v/%v/%v/", *bucket, *owner, *repo))
 	if err != nil {
 		err := fmt.Errorf("NewGCSLog: %v", err)
 		logAndPrintError(err)


### PR DESCRIPTION
Fixes an issue in mainter where incorrect logs were being loaded.

Consider the repository grpc/grpc. It scans the bucket and notices the
mutation log

grpc/grpc-java/foo.mutlog

It notes that the file _starts with_ "grpc/grpc" and is therefore
a valid mutation log. It then attempts to read the file
"grpc/grpc/foo.mutlog" which doesn't exist and crashes.

By adding the trailing "/" to our bucket name we will prevent this error