### PR TITLE
chore: update samplr's Dockerfiles

### DIFF
--- a/samplr/samplr-rtr/Dockerfile
+++ b/samplr/samplr-rtr/Dockerfile
@@ -34,8 +34,4 @@ FROM gcr.io/distroless/base
 COPY --from=build /go/bin/samplr-rtr /
 COPY --from=health /bin/grpc_health_probe /bin/grpc_health_probe
 
-WORKDIR /src
-
-COPY . .
-
 CMD ["/samplr-rtr"]

--- a/samplr/samplr-sprvsr/Dockerfile
+++ b/samplr/samplr-sprvsr/Dockerfile
@@ -24,7 +24,7 @@ WORKDIR /src/github.com/GoogleCloudPlatform/devrel-services/samplr
 RUN go install github.com/GoogleCloudPlatform/devrel-services/samplr/samplr-sprvsr
 
 FROM gcr.io/distroless/base
+
 COPY --from=build /go/bin/samplr-sprvsr /
-WORKDIR /src
-COPY . .
+
 CMD ["/samplr-sprvsr"]

--- a/samplr/samplrd/Dockerfile
+++ b/samplr/samplrd/Dockerfile
@@ -19,11 +19,12 @@ ENV GO111MODULE=on
 
 WORKDIR /src/github.com/GoogleCloudPlatform/devrel-services/
 COPY . .
+
 WORKDIR /src/github.com/GoogleCloudPlatform/devrel-services/samplr/samplrd
 
 RUN go install github.com/GoogleCloudPlatform/devrel-services/samplr/samplrd
 
-FROM golang:1.11-stretch
+FROM golang:1.13-stretch
 
 WORKDIR /
 COPY --from=build /go/bin/samplrd .


### PR DESCRIPTION
Dockerfiles were superfluously copying the source directory into the
final image.

Also bumped samplrd's version of the final image to golang:1.13-stretch
(was 1.11-stretch).