### PR TITLE
fix(samplr): samplr now passes go vet

### DIFF
--- a/samplr/samplr.go
+++ b/samplr/samplr.go
@@ -51,11 +51,11 @@ type Corpus struct {
 	debug   bool
 	syncing bool
 
-	watchedGitRepos []watchedGitRepo
+	watchedGitRepos []WatchedRepository
 
 	// github-specific
 
-	gitReposToAdd chan watchedGitRepo
+	gitReposToAdd chan WatchedRepository
 }
 
 // RLock grabs the corpus's read lock. Grabbing the read lock prevents
@@ -110,7 +110,7 @@ func (c *Corpus) Sync(ctx context.Context) error {
 	}
 	c.syncing = true
 
-	c.gitReposToAdd = make(chan watchedGitRepo)
+	c.gitReposToAdd = make(chan WatchedRepository)
 	c.mu.Unlock()
 
 	err := c.sync(ctx)
@@ -127,7 +127,7 @@ func (c *Corpus) Sync(ctx context.Context) error {
 func (c *Corpus) sync(ctx context.Context) error {
 	group, ctx := errgroup.WithContext(ctx)
 
-	updateGitRepo := func(gr watchedGitRepo) error {
+	updateGitRepo := func(gr WatchedRepository) error {
 		log.Printf("Beginning syncLoop for %v...", gr.ID())
 		for {
 			log.Printf("Polling %v ...", gr.ID())
@@ -169,7 +169,7 @@ func (c *Corpus) ForEachRepo(fn func(repo WatchedRepository) error) error {
 func (c *Corpus) ForEachRepoF(fn func(repo WatchedRepository) error, filter func(repo WatchedRepository) bool) error {
 	for _, repo := range c.watchedGitRepos {
 		if filter(repo) {
-			if err := fn(&repo); err != nil {
+			if err := fn(repo); err != nil {
 				return err
 			}
 		}

--- a/samplr/samplrctl/utils/utils.go
+++ b/samplr/samplrctl/utils/utils.go
@@ -40,19 +40,19 @@ func GetSnippets(ctx context.Context, d string) ([]*samplr.Snippet, error) {
 	repoName := ""
 	err = remotes.ForEach(func(re *git.Remote) error {
 		if re.Config() == nil {
-			errors.New("Remote has a nil Config")
+			return errors.New("Remote has a nil Config")
 		}
 		if re.Config().Name != "origin" {
 			return nil
 		}
 
 		if len(re.Config().URLs) == 0 {
-			errors.New("No URLs associated with remote")
+			return errors.New("No URLs associated with remote")
 		}
 
 		parts := strings.Split(re.Config().URLs[0], "/")
 		if len(parts) < 3 {
-			errors.New("Remote has an invalid URL")
+			return errors.New("Remote has an invalid URL")
 		}
 
 		repoName = parts[len(parts)-1]

--- a/samplr/watched_repository.go
+++ b/samplr/watched_repository.go
@@ -14,6 +14,8 @@
 
 package samplr
 
+import "context"
+
 // WatchedRepository represents a repository being watched by the Corpus
 type WatchedRepository interface {
 	// Unique Identifier of the Repository
@@ -31,6 +33,8 @@ type WatchedRepository interface {
 	Owner() string
 	// The name of the repository
 	RepositoryName() string
+	// Instructs the Repository to Update
+	Update(ctx context.Context) error
 }
 
 type RepositoryId struct {


### PR DESCRIPTION
Needed to change most of the structures to use pointers and interfaces
in order to not copy mutex lock values

Fixes #30 