### PR TITLE
feat(samplr): filter should apply before pages are created

### DIFF
--- a/samplr/samplrd/samplrapi/sample_service.go
+++ b/samplr/samplrd/samplrapi/sample_service.go
@@ -355,7 +355,7 @@ func (s *SampleServiceServer) ListSnippets(ctx context.Context, req *drghs_v1.Li
 		}, repositoryFilter)
 
 		// Filter Snippets
-		filteredSnippet := make([]*samplr.Snippet, 0)
+		filteredSnippets := make([]*samplr.Snippet, 0)
 		for _, v := range snippets {
 			pv, err := makeSnippetPB(v)
 			if err != nil {
@@ -370,12 +370,12 @@ func (s *SampleServiceServer) ListSnippets(ctx context.Context, req *drghs_v1.Li
 			}
 
 			if should {
-				filteredSnippet = append(filteredSnippet, v)
+				filteredSnippets = append(filteredSnippets, v)
 			}
 		}
 
 		// Create Page
-		t, err := s.sp.CreatePage(filteredSnippet)
+		t, err := s.sp.CreatePage(filteredSnippets)
 		if err != nil {
 			log.Error(err)
 			return nil, err
@@ -398,7 +398,12 @@ func (s *SampleServiceServer) ListSnippets(ctx context.Context, req *drghs_v1.Li
 		}
 	}
 
-	protoversions := makeSnippetProtoversion(pg)
+	protoversions, err := makeSnippetProtoversion(pg)
+	if err != nil {
+		log.Errorf("Could not create the snippet protoversion: %v", err)
+		return nil, err
+	}
+
 	return &drghs_v1.ListSnippetsResponse{
 		Snippets:      protoversions,
 		NextPageToken: nextToken,
@@ -528,7 +533,11 @@ func (s *SampleServiceServer) ListSnippetVersions(ctx context.Context, req *drgh
 		}
 	}
 
-	protoversions := makeSnippetVersionProtoversion(pg)
+	protoversions, err := makeSnippetVersionProtoversion(pg)
+	if err != nil {
+		log.Errorf("Could not create the snippet version protoversion: %v", err)
+		return nil, err
+	}
 	return &drghs_v1.ListSnippetVersionsResponse{
 		SnippetVersions: protoversions,
 		NextPageToken:   nextToken,

--- a/samplr/samplrd/samplrapi/translation_utils.go
+++ b/samplr/samplrd/samplrapi/translation_utils.go
@@ -99,18 +99,26 @@ func makeGitCommitPB(commit *samplr.GitCommit) (*drghs_v1.GitCommit, error) {
 	}, nil
 }
 
-func makeSnippetProtoversion(snippets []*samplr.Snippet) []*drghs_v1.Snippet {
+func makeSnippetProtoversion(snippets []*samplr.Snippet) ([]*drghs_v1.Snippet, error) {
 	protoversions := make([]*drghs_v1.Snippet, len(snippets))
 	for idx, s := range snippets {
-		protoversions[idx], _ = makeSnippetPB(s)
+		snippet, err := makeSnippetPB(s)
+		if err != nil {
+			return nil, err
+		}
+		protoversions[idx] = snippet
 	}
-	return protoversions
+	return protoversions, nil
 }
 
-func makeSnippetVersionProtoversion(versions []samplr.SnippetVersion) []*drghs_v1.SnippetVersion {
+func makeSnippetVersionProtoversion(versions []samplr.SnippetVersion) ([]*drghs_v1.SnippetVersion, error) {
 	protoversions := make([]*drghs_v1.SnippetVersion, len(versions))
 	for idx, v := range versions {
-		protoversions[idx], _ = makeSnippetVersionPB(v)
+		snippetVersion, err := makeSnippetVersionPB(v)
+		if err != nil {
+			return nil, err
+		}
+		protoversions[idx] = snippetVersion
 	}
-	return protoversions
+	return protoversions, nil
 }

--- a/samplr/samplrd/samplrapi/translation_utils.go
+++ b/samplr/samplrd/samplrapi/translation_utils.go
@@ -98,3 +98,19 @@ func makeGitCommitPB(commit *samplr.GitCommit) (*drghs_v1.GitCommit, error) {
 		Sha:            commit.Hash,
 	}, nil
 }
+
+func makeSnippetProtoversion(snippets []*samplr.Snippet) []*drghs_v1.Snippet {
+	protoversions := make([]*drghs_v1.Snippet, len(snippets))
+	for idx, s := range snippets {
+		protoversions[idx], _ = makeSnippetPB(s)
+	}
+	return protoversions
+}
+
+func makeSnippetVersionProtoversion(versions []samplr.SnippetVersion) []*drghs_v1.SnippetVersion {
+	protoversions := make([]*drghs_v1.SnippetVersion, len(versions))
+	for idx, v := range versions {
+		protoversions[idx], _ = makeSnippetVersionPB(v)
+	}
+	return protoversions
+}


### PR DESCRIPTION
  - Move filtering when Page is created
  - Add utils function to create protoversions in place of the filtering handling

Fixes #35
