### PR TITLE
feat(samplr): add Kubernetes cron to update

### DIFF
--- a/samplr/kubernetes/deployment.yaml
+++ b/samplr/kubernetes/deployment.yaml
@@ -191,3 +191,23 @@ metadata:
 spec:
   domains:
     - samplr.endpoints.PROJECT_ID.cloud.goog
+---
+apiVersion: batch/v1beta1
+kind: CronJob
+metadata:
+  name: samplrd-sprvsr-update
+spec:
+  schedule: "30 0 * * *"
+  concurrencyPolicy: Forbid
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          containers:
+          - name: update
+            image: busybox
+            args:
+            - /bin/sh
+            - -c
+            - date; wget -O - http://samplrd-sprvsr-cip/update
+          restartPolicy: Never


### PR DESCRIPTION
Adds cron job to the k8s spec that tells samplrd-sprvsr to update every
day at 00:30.