### PR TITLE
fix(maintnerd): Case-insensitive sort for labels

### DIFF
--- a/drghs-worker/maintnerd/api/v1beta1/common.go
+++ b/drghs-worker/maintnerd/api/v1beta1/common.go
@@ -177,7 +177,7 @@ func makeIssuePB(issue *maintner.GitHubIssue, rID maintner.GitHubRepoID, include
 			labels[i] = l.Name
 			i++
 		}
-		sort.Strings(labels)
+		sort.Slice(labels, func(i, j int) bool { return strings.ToLower(labels[i]) < strings.ToLower(labels[j]) })
 	}
 
 	if paths == nil || contains(paths, "labels") {
@@ -230,36 +230,46 @@ func fillFromLabels(s *drghs_v1.Issue, labels []string, fm *field_mask.FieldMask
 
 	for _, l := range labels {
 		lowercaseName := strings.ToLower(l)
+		if priorityUnknown == true {
+			switch {
+			case strings.Contains(lowercaseName, "p0"):
+				priority = drghs_v1.Issue_P0
+				priorityUnknown = false
+			case strings.Contains(lowercaseName, "p1"):
+				priority = drghs_v1.Issue_P1
+				priorityUnknown = false
+			case strings.Contains(lowercaseName, "p2"):
+				priority = drghs_v1.Issue_P2
+				priorityUnknown = false
+			case strings.Contains(lowercaseName, "p3"):
+				priority = drghs_v1.Issue_P3
+				priorityUnknown = false
+			case strings.Contains(lowercaseName, "p4"):
+				priority = drghs_v1.Issue_P4
+				priorityUnknown = false
+			}
+		}
+
+		if issueType == drghs_v1.Issue_GITHUB_ISSUE_TYPE_UNSPECIFIED {
+			switch {
+			case matchesAny(lowercaseName, bugLabels):
+				issueType = drghs_v1.Issue_BUG
+			case strings.Contains(lowercaseName, "enhanc"):
+				issueType = drghs_v1.Issue_FEATURE
+			case strings.Contains(lowercaseName, "feat"):
+				issueType = drghs_v1.Issue_FEATURE
+			case strings.Contains(lowercaseName, "addition"):
+				issueType = drghs_v1.Issue_FEATURE
+			case strings.Contains(lowercaseName, "question"):
+				issueType = drghs_v1.Issue_QUESTION
+			case strings.Contains(lowercaseName, "cleanup"):
+				issueType = drghs_v1.Issue_CLEANUP
+			case strings.Contains(lowercaseName, "process"):
+				issueType = drghs_v1.Issue_PROCESS
+			}
+		}
+
 		switch {
-		case strings.Contains(lowercaseName, "p0"):
-			priority = drghs_v1.Issue_P0
-			priorityUnknown = false
-		case strings.Contains(lowercaseName, "p1"):
-			priority = drghs_v1.Issue_P1
-			priorityUnknown = false
-		case strings.Contains(lowercaseName, "p2"):
-			priority = drghs_v1.Issue_P2
-			priorityUnknown = false
-		case strings.Contains(lowercaseName, "p3"):
-			priority = drghs_v1.Issue_P3
-			priorityUnknown = false
-		case strings.Contains(lowercaseName, "p4"):
-			priority = drghs_v1.Issue_P4
-			priorityUnknown = false
-		case matchesAny(lowercaseName, bugLabels):
-			issueType = drghs_v1.Issue_BUG
-		case strings.Contains(lowercaseName, "enhanc"):
-			issueType = drghs_v1.Issue_FEATURE
-		case strings.Contains(lowercaseName, "feat"):
-			issueType = drghs_v1.Issue_FEATURE
-		case strings.Contains(lowercaseName, "addition"):
-			issueType = drghs_v1.Issue_FEATURE
-		case strings.Contains(lowercaseName, "question"):
-			issueType = drghs_v1.Issue_QUESTION
-		case strings.Contains(lowercaseName, "cleanup"):
-			issueType = drghs_v1.Issue_CLEANUP
-		case strings.Contains(lowercaseName, "process"):
-			issueType = drghs_v1.Issue_PROCESS
 		case strings.Contains(lowercaseName, "blocked"):
 			blocked = true
 		case strings.Contains(lowercaseName, "blocking"):

--- a/drghs-worker/maintnerd/api/v1beta1/common_test.go
+++ b/drghs-worker/maintnerd/api/v1beta1/common_test.go
@@ -53,13 +53,14 @@ func TestMakeIssuePBFieldMask(t *testing.T) {
 		Body:        "body",
 		Number:      1234,
 		Labels: map[int64]*maintner.GitHubLabel{
-			1: &maintner.GitHubLabel{Name: "Bug"},
+			1: &maintner.GitHubLabel{Name: "bug"},
 			2: &maintner.GitHubLabel{Name: "foo"},
 			3: &maintner.GitHubLabel{Name: "Zebra"},
 			4: &maintner.GitHubLabel{Name: "bar"},
-			5: &maintner.GitHubLabel{Name: "p0"},
-			6: &maintner.GitHubLabel{Name: "blocked"},
-			7: &maintner.GitHubLabel{Name: "blocking"},
+			5: &maintner.GitHubLabel{Name: "Feat"},
+			6: &maintner.GitHubLabel{Name: "p0"},
+			7: &maintner.GitHubLabel{Name: "blocked"},
+			8: &maintner.GitHubLabel{Name: "blocking"},
 		},
 	}
 
@@ -101,7 +102,7 @@ func TestMakeIssuePBFieldMask(t *testing.T) {
 				IssueId:         1234,
 				Url:             "https://github.com/foo/bar/issues/1234",
 				Repo:            "foo/bar",
-				Labels:          []string{"Bug", "Zebra", "bar", "blocked", "blocking", "foo", "p0"},
+				Labels:          []string{"bar", "blocked", "blocking", "bug", "Feat", "foo", "p0", "Zebra"},
 				Priority:        drghs_v1.Issue_P0,
 				PriorityUnknown: false,
 				IssueType:       drghs_v1.Issue_BUG,
@@ -186,7 +187,7 @@ func TestMakeIssuePBFieldMask(t *testing.T) {
 		},
 		{
 			fm:   &field_mask.FieldMask{Paths: []string{"labels"}},
-			want: &drghs_v1.Issue{Labels: []string{"Bug", "Zebra", "bar", "blocked", "blocking", "foo", "p0"}},
+			want: &drghs_v1.Issue{Labels: []string{"bar", "blocked", "blocking", "bug", "Feat", "foo", "p0", "Zebra"}},
 		},
 		{
 			fm:   &field_mask.FieldMask{Paths: []string{"priority"}},


### PR DESCRIPTION
Also, enforces deterministic selection of priority/issueType. First match always wins.
