### PR TITLE
fix(k8s_supervisor): fix bug with redundant resource creation

### DIFF
--- a/sprvsr/go.mod
+++ b/sprvsr/go.mod
@@ -21,6 +21,7 @@ require (
 	github.com/GoogleCloudPlatform/devrel-services/repos v0.0.0
 
 	github.com/deckarep/golang-set v1.7.1
+	github.com/google/go-cmp v0.3.0
 	github.com/gorilla/mux v1.7.2
 	github.com/gregjones/httpcache v0.0.0-20190203031600-7a902570cb17 // indirect
 	github.com/matryer/is v1.2.0

--- a/sprvsr/go.sum
+++ b/sprvsr/go.sum
@@ -49,6 +49,7 @@ github.com/golang/protobuf v1.3.2/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5y
 github.com/google/btree v0.0.0-20160524151835-7d79101e329e/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
 github.com/google/btree v0.0.0-20180813153112-4030bb1f1f0c/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
 github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5aqRK0M=
+github.com/google/go-cmp v0.3.0 h1:crn/baboCvb5fXaQ0IJ1SGTsTVrWpDsCWC8EGETZijY=
 github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/google/go-github v17.0.0+incompatible/go.mod h1:zLgOLi98H3fifZn+44m+umXrS52loVEgC2AApnigrVQ=
 github.com/google/go-querystring v1.0.0/go.mod h1:odCYkC5MyYFN7vkCjXpyrEuKhc/BUO6wN/zVPAxq5ck=


### PR DESCRIPTION
The code calculating set differences works, but only in situations where
the compiler is smart enough to make the inference of equality between
structs.

Now change the key of the map used for setDifference to a string. This
fixes redundant resource creation and deletion from the k8s cluster.