### PR TITLE
fix(maintner): add retry logic

### DIFF
--- a/drghs-worker/maintner-rtr/Dockerfile
+++ b/drghs-worker/maintner-rtr/Dockerfile
@@ -30,9 +30,6 @@ RUN GRPC_HEALTH_PROBE_VERSION=v0.2.0 && \
     chmod +x /bin/grpc_health_probe
 
 FROM gcr.io/distroless/base
-# Enable verbose GRPC debug logging
-ENV GRPC_GO_LOG_VERBOSITY_LEVEL=99 
-ENV GRPC_GO_LOG_SEVERITY_LEVEL=info
 
 COPY --from=build /go/bin/maintner-rtr /
 COPY --from=health /bin/grpc_health_probe /bin/grpc_health_probe

--- a/drghs-worker/maintner-rtr/main.go
+++ b/drghs-worker/maintner-rtr/main.go
@@ -283,7 +283,7 @@ func unaryInterceptorLog(ctx context.Context, req interface{}, info *grpc.UnaryS
 func buildRetryInterceptor() grpc.UnaryClientInterceptor {
 	opts := []grpc_retry.CallOption{
 		grpc_retry.WithBackoff(grpc_retry.BackoffExponential(500 * time.Millisecond)),
-		grpc_retry.WithCodes(codes.NotFound, codes.Aborted),
+		grpc_retry.WithCodes(codes.NotFound, codes.Aborted, codes.Unavailable, codes.DeadlineExceeded),
 		grpc_retry.WithMax(5),
 	}
 	return grpc_retry.UnaryClientInterceptor(opts...)

--- a/drghs-worker/maintner-swpr/main.go
+++ b/drghs-worker/maintner-swpr/main.go
@@ -450,7 +450,7 @@ func (t limitTransport) RoundTrip(r *http.Request) (*http.Response, error) {
 func buildRetryInterceptor() grpc.UnaryClientInterceptor {
 	opts := []grpc_retry.CallOption{
 		grpc_retry.WithBackoff(grpc_retry.BackoffExponential(500 * time.Millisecond)),
-		grpc_retry.WithCodes(codes.NotFound, codes.Aborted),
+		grpc_retry.WithCodes(codes.NotFound, codes.Aborted, codes.Unavailable, codes.DeadlineExceeded),
 		grpc_retry.WithMax(5),
 	}
 	return grpc_retry.UnaryClientInterceptor(opts...)

--- a/drghs-worker/maintnerd/Dockerfile
+++ b/drghs-worker/maintnerd/Dockerfile
@@ -31,11 +31,6 @@ RUN GRPC_HEALTH_PROBE_VERSION=v0.2.0 && \
 
 FROM golang:1.13
 
-ENV GRPC_TRACE=all
-ENV GRPC_VERBOSITY=DEBUG
-ENV GRPC_GO_LOG_VERBOSITY_LEVEL=2
-ENV GRPC_GO_LOG_SEVERITY_LEVEL=info
-
 COPY --from=build /go/bin/maintnerd /
 COPY --from=health /bin/grpc_health_probe /bin/grpc_health_probe
 


### PR DESCRIPTION
Expands retry logic to "unavailable" in order to help fix intermittent
networking issues.

Removes verbose gRPC debugging.