### PR TITLE
fix(samplr): remove whitespace from Snippet's Language

### DIFF
--- a/samplr/snippet.go
+++ b/samplr/snippet.go
@@ -172,12 +172,7 @@ func CalculateSnippets(o, r string, iter git.CommitIter) ([]*Snippet, error) {
 			}
 
 			language := enry.GetLanguage(file.Name, []byte(content))
-			if language == "C#" {
-				language = "CSHARP"
-			} else if language == "C++" {
-				language = "CPP"
-			}
-			language = strings.ToUpper(language)
+			language = cleanLanguage(language)
 
 			fle := File{
 				FilePath:  file.Name,
@@ -535,4 +530,16 @@ func snippetsEquivalent(a SnippetVersion, b SnippetVersion) bool {
 	}
 	// Last case, check the file paths are the same
 	return a.File.FilePath == b.File.FilePath && strEq(a.Lines, b.Lines)
+}
+
+func cleanLanguage(language string) string {
+	if language == "C#" {
+		language = "CSHARP"
+	} else if language == "C++" {
+		language = "CPP"
+	}
+	language = strings.ToUpper(language)
+	language = strings.ReplaceAll(language, " ", "_")
+
+	return language
 }

--- a/samplr/snippet.go
+++ b/samplr/snippet.go
@@ -540,6 +540,7 @@ func cleanLanguage(language string) string {
 	}
 	language = strings.ToUpper(language)
 	language = strings.ReplaceAll(language, " ", "_")
+	language = strings.ReplaceAll(language, "-", "_")
 
 	return language
 }

--- a/samplr/snippet_test.go
+++ b/samplr/snippet_test.go
@@ -1240,8 +1240,13 @@ func TestCleanLanguage(t *testing.T) {
 		},
 		{
 			Name:     "Spaces to underscores",
-			Language: "Maven Pom",
-			Want:     "MAVEN_POM",
+			Language: "Ma ven Pom",
+			Want:     "MA_VEN_POM",
+		},
+		{
+			Name:     "Hyphens to underscores",
+			Language: "Ma-ven-Pom",
+			Want:     "MA_VEN_POM",
 		},
 	}
 	for _, c := range cases {

--- a/samplr/snippet_test.go
+++ b/samplr/snippet_test.go
@@ -1216,3 +1216,38 @@ func TestProcessPreviouslySeenSnippets(t *testing.T) {
 		}
 	}
 }
+
+func TestCleanLanguage(t *testing.T) {
+	cases := []struct {
+		Name     string
+		Language string
+		Want     string
+	}{
+		{
+			Name:     "Converts C#",
+			Language: "C#",
+			Want:     "CSHARP",
+		},
+		{
+			Name:     "Converts C++",
+			Language: "C++",
+			Want:     "CPP",
+		},
+		{
+			Name:     "Puts to uppercase",
+			Language: "Javascript",
+			Want:     "JAVASCRIPT",
+		},
+		{
+			Name:     "Spaces to underscores",
+			Language: "Maven Pom",
+			Want:     "MAVEN_POM",
+		},
+	}
+	for _, c := range cases {
+		got := cleanLanguage(c.Language)
+		if diff := cmp.Diff(c.Want, got); diff != "" {
+			t.Errorf("%v failed. Diff (-want, +got)\n%v", c.Name, diff)
+		}
+	}
+}


### PR DESCRIPTION
A snippet is accessed in the API via it's Name (which includes the
language the snippet is written in) in a URL, which cannot support
whitespace.

Adds cleanLanguage function to facilitate tests.

Fixes #113