### PR TITLE
fix(maintner): support GetIssue with "." in name

### DIFF
--- a/drghs-worker/maintnerd/api/v1beta1/issue_service.go
+++ b/drghs-worker/maintnerd/api/v1beta1/issue_service.go
@@ -39,7 +39,7 @@ var _ drghs_v1.IssueServiceServer = &IssueServiceV1{}
 
 const defaultFilter = "true"
 
-var issueNumReg = regexp.MustCompile(`^[\w-]+\/[\w-]+\/issues/(\d+)$`)
+var issueNumReg = regexp.MustCompile(`^[\w.-]+\/[\w.-]+\/issues/(\d+)$`)
 
 // IssueServiceV1 is an implementation of the gRPC service drghs_v1.IssueServiceServer
 type IssueServiceV1 struct {

--- a/drghs-worker/maintnerd/api/v1beta1/issue_service_test.go
+++ b/drghs-worker/maintnerd/api/v1beta1/issue_service_test.go
@@ -171,6 +171,7 @@ func TestGetIssueID(t *testing.T) {
 		{"/api/v1/foo/bar/issues/1", -1},
 		{"/foo/bar/issues/1", -1},
 		{"foo/bar/issues/13", 13},
+		{"foo.bar/baz.biz/issues/12", 12},
 	}
 	for _, tt := range tests {
 		got := getIssueID(tt.id)


### PR DESCRIPTION
Fixes bug where calling GetIssue on a repository which had a "." in it's
name was returning not found as the regex was incomplete.