### PR TITLE
fix(maintner): no longer fail on ListIssues

### DIFF
--- a/drghs-worker/maintner-rtr/main.go
+++ b/drghs-worker/maintner-rtr/main.go
@@ -215,14 +215,16 @@ func (s *reverseProxyServer) ListRepositories(ctx context.Context, r *drghs_v1.L
 		)
 
 		if err != nil {
-			return nil, err
+			log.Warnf("got error dialing to repo: %v path: %v err: %v", tr.String(), pth, err)
+			continue
 		}
 
 		client := drghs_v1.NewIssueServiceClient(conn)
 		// Naive right now... every service has exactly one repo
 		srepos, err := getTrackedRepositories(ctx, client)
 		if err != nil {
-			return nil, err
+			log.Warnf("got error listing repositories for repo: %v path: %v err: %v", tr.String(), pth, err)
+			continue
 		}
 
 		resp.Repositories = append(resp.Repositories, srepos...)

--- a/drghs-worker/maintner-swpr/main.go
+++ b/drghs-worker/maintner-swpr/main.go
@@ -256,7 +256,8 @@ func getMaintnerIssuesForRepo(ctx context.Context, tr *repos.TrackedRepository, 
 		grpc.WithUnaryInterceptor(buildRetryInterceptor()),
 	)
 	if err != nil {
-		log.Fatal(err)
+		log.Error(err)
+		return nil, err
 	}
 	defer conn.Close()
 
@@ -298,6 +299,7 @@ func getTrackedRepositories(ctx context.Context, c drghs_v1.IssueServiceClient) 
 			PageSize:  500,
 		})
 		if err != nil {
+			log.Warnf("got error while listing repositories: %v", err)
 			return nil, err
 		}
 		ret = append(ret, rep.Repositories...)
@@ -322,7 +324,7 @@ func flagIssuesTombstoned(ctx context.Context, tr *repos.TrackedRepository, repo
 		grpc.WithUnaryInterceptor(buildRetryInterceptor()),
 	)
 	if err != nil {
-		log.Fatal(err)
+		return err
 	}
 	defer conn.Close()
 


### PR DESCRIPTION
In maintner-rtr when we were responding to a ListIssues RPC if any of
the deployments came back with an error, we would abandon the whole
request and return the error code (this included if we dialed to
a deployment). Now, log the error and continue on to the rest of the
errors.

This had a downstream effect on swpr (it could not do its work as the
list of repositories was always empty with an error).
