### PR TITLE
fix(sweeper): read from storage bucket

### DIFF
--- a/drghs-worker/kubernetes/deployment.yaml
+++ b/drghs-worker/kubernetes/deployment.yaml
@@ -219,7 +219,8 @@ spec:
           - name: maintner-swpr
             image: gcr.io/PROJECT_ID/maintner-swpr:BUILD_ID
             args: [
-              "--rtr-address=esp-maintnerd-rtr-np:5000",
+              "--settings-bucket=SETTINGS_BUCKET",
+              "--repos-file=REPOS_FILE",
               "--project-id=PROJECT_ID",
             ]
             env:


### PR DESCRIPTION
Now in sweeper, read directly from the storage bucket as opposed to
calling maintner-rtr.

This was causing issues as the router service was flakey and would cause
the sweeper job to fail