### PR TITLE
fix(maintner): disable Service Links

### DIFF
--- a/drghs-worker/maintner-sprvsr/main.go
+++ b/drghs-worker/maintner-sprvsr/main.go
@@ -275,6 +275,7 @@ func buildDeployment(sasecretname, githubsecretname, githubsecretkey string, ta 
 	if err != nil {
 		return nil, err
 	}
+	enableServiceLinks := false
 	return &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: dep,
@@ -296,6 +297,7 @@ func buildDeployment(sasecretname, githubsecretname, githubsecretkey string, ta 
 					},
 				},
 				Spec: apiv1.PodSpec{
+					EnableServiceLinks: &enableServiceLinks,
 					Volumes: []apiv1.Volume{
 						apiv1.Volume{
 							Name: "gcp-sa",


### PR DESCRIPTION
In Kubernetes, if there are services in the Cluster, by default, when a
new Pod is created, kubelet will add environment variables to the
running process in order to allow containers to "discover" other
containers.

This eventually runs into a scaling problem as there is an upper limit
on the maximum number of arguments to a running process. This causes the
init process that spawns the container to fail as there are too many
arguments.

This commit disables Service Links for the maintner pods as we use DNS
to handle our requests (and maintner pods do not communicate with each
other)

See: https://github.com/kubernetes/kubernetes/issues/84539 for more
details.